### PR TITLE
Simplify the types to remove Topic and Unsubscriber.

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -6,28 +6,25 @@ package pubsub_test
 import (
 	"time"
 
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/pubsub"
 )
 
-type BenchmarkSuite struct {
-	testing.IsolationSuite
-}
+type BenchmarkSuite struct{}
 
 var _ = gc.Suite(&BenchmarkSuite{})
 
 func (*BenchmarkSuite) BenchmarkStructuredNoConversions(c *gc.C) {
 	hub := pubsub.NewStructuredHub(nil)
-	topic := pubsub.Topic("benchmarking")
+	topic := "benchmarking"
 	counter := 0
-	sub, err := hub.Subscribe(pubsub.MatchAll, func(topic pubsub.Topic, data map[string]interface{}) {
+	unsub, err := hub.SubscribeMatch(pubsub.MatchAll, func(topic string, data map[string]interface{}) {
 		counter++
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	defer sub.Unsubscribe()
+	defer unsub()
 	failedCount := 0
 	for i := 0; i < c.N; i++ {
 		done, err := hub.Publish(topic, nil)
@@ -45,14 +42,14 @@ func (*BenchmarkSuite) BenchmarkStructuredNoConversions(c *gc.C) {
 
 func (*BenchmarkSuite) BenchmarkStructuredSerialize(c *gc.C) {
 	hub := pubsub.NewStructuredHub(nil)
-	topic := pubsub.Topic("benchmarking")
+	topic := "benchmarking"
 	counter := 0
-	sub, err := hub.Subscribe(pubsub.MatchAll, func(topic pubsub.Topic, data Emitter, err error) {
+	unsub, err := hub.SubscribeMatch(pubsub.MatchAll, func(topic string, data Emitter, err error) {
 		c.Assert(err, jc.ErrorIsNil)
 		counter++
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	defer sub.Unsubscribe()
+	defer unsub()
 	failedCount := 0
 	data := Emitter{
 		Origin:  "master",

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,9 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package pubsub
+
+// Exported to test matching.
+func MultiplexerMatch(m Multiplexer, topic string) bool {
+	return m.(*multiplexer).match(topic)
+}

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,16 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package pubsub
+
+// Logger represents methods called by this package to a logging
+// system.
+type Logger interface {
+	Debugf(format string, values ...interface{})
+	Tracef(format string, values ...interface{})
+}
+
+type noOpLogger struct{}
+
+func (noOpLogger) Debugf(format string, values ...interface{}) {}
+func (noOpLogger) Tracef(format string, values ...interface{}) {}

--- a/matcher.go
+++ b/matcher.go
@@ -5,49 +5,25 @@ package pubsub
 
 import "regexp"
 
-// Topic represents a message that can be subscribed to.
-type Topic string
-
-// TopicMatcher defines the Match method that is used to determine
-// if the subscriber should be notified about a particular message.
-type TopicMatcher interface {
-	Match(Topic) bool
+func equalTopic(match string) func(topic string) bool {
+	return func(topic string) bool {
+		return match == topic
+	}
 }
-
-// Match implements TopicMatcher. One topic matches another if they
-// are equal.
-func (t Topic) Match(topic Topic) bool {
-	return t == topic
-}
-
-// RegexpMatcher allows standard regular expressions to be used as
-// TopicMatcher values. RegexpMatches can be created using the short-hand
-// function MatchRegexp function that wraps regexp.MustCompile.
-type RegexpMatcher regexp.Regexp
 
 // MatchRegexp expects a valid regular expression. If the expression
 // passed in is not valid, the function panics. The expected use of this
 // is to be able to do something like:
 //
-//     hub.Subscribe(pubsub.MatchRegex("prefix.*suffix"), handler)
-func MatchRegexp(expression string) TopicMatcher {
-	return (*RegexpMatcher)(regexp.MustCompile(expression))
-}
-
-// Match implements TopicMatcher.
-//
-// The topic matches if the regular expression matches the topic.
-func (m *RegexpMatcher) Match(topic Topic) bool {
-	r := (*regexp.Regexp)(m)
-	return r.MatchString(string(topic))
-}
-
-type allMatcher struct{}
-
-// Match implements TopicMatcher.  All topics match for the allMatcher.
-func (*allMatcher) Match(topic Topic) bool {
-	return true
+//     hub.SubscribeMatch(pubsub.MatchRegex("prefix.*suffix"), handler)
+func MatchRegexp(expression string) func(topic string) bool {
+	r := regexp.MustCompile(expression)
+	return func(topic string) bool {
+		return r.MatchString(string(topic))
+	}
 }
 
 // MatchAll is a topic matcher that matches all topics.
-var MatchAll TopicMatcher = (*allMatcher)(nil)
+func MatchAll(_ string) bool {
+	return true
+}

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -4,43 +4,31 @@
 package pubsub_test
 
 import (
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/pubsub"
 )
 
-type MatcherSuite struct {
-	testing.IsolationSuite
-}
+type MatcherSuite struct{}
 
 var (
 	_ = gc.Suite(&MatcherSuite{})
 
-	first       pubsub.Topic = "first"
-	firstdot    pubsub.Topic = "first.next"
-	second      pubsub.Topic = "second"
-	secondfirst pubsub.Topic = "second.first.next"
-	space       pubsub.Topic = "a topic"
+	first       = "first"
+	firstdot    = "first.next"
+	second      = "second"
+	secondfirst = "second.first.next"
+	space       = "a topic"
 )
-
-func (*MatcherSuite) TestTopicMatches(c *gc.C) {
-	var matcher pubsub.TopicMatcher = first
-	c.Check(matcher.Match(first), jc.IsTrue)
-	c.Check(matcher.Match(firstdot), jc.IsFalse)
-	c.Check(matcher.Match(second), jc.IsFalse)
-	c.Check(matcher.Match(secondfirst), jc.IsFalse)
-	c.Check(matcher.Match(space), jc.IsFalse)
-}
 
 func (*MatcherSuite) TestMatchAll(c *gc.C) {
 	matcher := pubsub.MatchAll
-	c.Check(matcher.Match(first), jc.IsTrue)
-	c.Check(matcher.Match(firstdot), jc.IsTrue)
-	c.Check(matcher.Match(second), jc.IsTrue)
-	c.Check(matcher.Match(secondfirst), jc.IsTrue)
-	c.Check(matcher.Match(space), jc.IsTrue)
+	c.Check(matcher(first), jc.IsTrue)
+	c.Check(matcher(firstdot), jc.IsTrue)
+	c.Check(matcher(second), jc.IsTrue)
+	c.Check(matcher(secondfirst), jc.IsTrue)
+	c.Check(matcher(space), jc.IsTrue)
 }
 
 func (*MatcherSuite) TestMatchRegexpPanicsOnInvalid(c *gc.C) {
@@ -49,9 +37,9 @@ func (*MatcherSuite) TestMatchRegexpPanicsOnInvalid(c *gc.C) {
 
 func (*MatcherSuite) TestMatchRegexp(c *gc.C) {
 	matcher := pubsub.MatchRegexp("first.*")
-	c.Check(matcher.Match(first), jc.IsTrue)
-	c.Check(matcher.Match(firstdot), jc.IsTrue)
-	c.Check(matcher.Match(second), jc.IsFalse)
-	c.Check(matcher.Match(secondfirst), jc.IsTrue)
-	c.Check(matcher.Match(space), jc.IsFalse)
+	c.Check(matcher(first), jc.IsTrue)
+	c.Check(matcher(firstdot), jc.IsTrue)
+	c.Check(matcher(second), jc.IsFalse)
+	c.Check(matcher(secondfirst), jc.IsTrue)
+	c.Check(matcher(space), jc.IsFalse)
 }

--- a/simplehub_test.go
+++ b/simplehub_test.go
@@ -5,25 +5,17 @@ package pubsub_test
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/pubsub"
 )
 
-type SimpleHubSuite struct {
-	testing.LoggingCleanupSuite
-}
+type SimpleHubSuite struct{}
 
-var (
-	_ = gc.Suite(&SimpleHubSuite{})
-
-	topic pubsub.Topic = "testing"
-)
+var _ = gc.Suite(&SimpleHubSuite{})
 
 func waitForMessageHandlingToBeComplete(c *gc.C, done <-chan struct{}) {
 	select {
@@ -37,19 +29,19 @@ func waitForMessageHandlingToBeComplete(c *gc.C, done <-chan struct{}) {
 
 func (*SimpleHubSuite) TestPublishNoSubscribers(c *gc.C) {
 	hub := pubsub.NewSimpleHub(nil)
-	done := hub.Publish(topic, nil)
+	done := hub.Publish("topic", nil)
 	waitForMessageHandlingToBeComplete(c, done)
 }
 
 func (*SimpleHubSuite) TestPublishOneSubscriber(c *gc.C) {
 	var called bool
 	hub := pubsub.NewSimpleHub(nil)
-	hub.Subscribe(topic, func(topic pubsub.Topic, data interface{}) {
-		c.Check(topic, gc.Equals, topic)
+	hub.Subscribe("topic", func(topic string, data interface{}) {
+		c.Check(topic, gc.Equals, "topic")
 		c.Check(data, gc.IsNil)
 		called = true
 	})
-	done := hub.Publish(topic, nil)
+	done := hub.Publish("topic", nil)
 
 	waitForMessageHandlingToBeComplete(c, done)
 	c.Assert(called, jc.IsTrue)
@@ -58,10 +50,10 @@ func (*SimpleHubSuite) TestPublishOneSubscriber(c *gc.C) {
 func (*SimpleHubSuite) TestPublishCompleterWaits(c *gc.C) {
 	wait := make(chan struct{})
 	hub := pubsub.NewSimpleHub(nil)
-	hub.Subscribe(topic, func(topic pubsub.Topic, data interface{}) {
+	hub.Subscribe("topic", func(topic string, data interface{}) {
 		<-wait
 	})
-	done := hub.Publish(topic, nil)
+	done := hub.Publish("topic", nil)
 
 	select {
 	case <-done:
@@ -76,32 +68,29 @@ func (*SimpleHubSuite) TestPublishCompleterWaits(c *gc.C) {
 }
 
 func (*SimpleHubSuite) TestSubscriberExecsInOrder(c *gc.C) {
-	mutex := sync.Mutex{}
-	var calls []pubsub.Topic
+	var calls []string
 	hub := pubsub.NewSimpleHub(nil)
-	hub.Subscribe(pubsub.MatchRegexp("test.*"), func(topic pubsub.Topic, data interface{}) {
-		mutex.Lock()
-		defer mutex.Unlock()
+	hub.SubscribeMatch(pubsub.MatchRegexp("test.*"), func(topic string, data interface{}) {
 		calls = append(calls, topic)
 	})
 	var lastCall <-chan struct{}
 	for i := 0; i < 5; i++ {
-		lastCall = hub.Publish(pubsub.Topic(fmt.Sprintf("test.%v", i)), nil)
+		lastCall = hub.Publish(fmt.Sprintf("test.%v", i), nil)
 	}
 
 	waitForMessageHandlingToBeComplete(c, lastCall)
-	c.Assert(calls, jc.DeepEquals, []pubsub.Topic{"test.0", "test.1", "test.2", "test.3", "test.4"})
+	c.Assert(calls, jc.DeepEquals, []string{"test.0", "test.1", "test.2", "test.3", "test.4"})
 }
 
 func (*SimpleHubSuite) TestPublishNotBlockedByHandlerFunc(c *gc.C) {
 	wait := make(chan struct{})
 	hub := pubsub.NewSimpleHub(nil)
-	hub.Subscribe(topic, func(topic pubsub.Topic, data interface{}) {
+	hub.Subscribe("topic", func(topic string, data interface{}) {
 		<-wait
 	})
 	var lastCall <-chan struct{}
 	for i := 0; i < 5; i++ {
-		lastCall = hub.Publish(topic, nil)
+		lastCall = hub.Publish("topic", nil)
 	}
 	// release the handlers
 	close(wait)
@@ -111,51 +100,52 @@ func (*SimpleHubSuite) TestPublishNotBlockedByHandlerFunc(c *gc.C) {
 
 func (*SimpleHubSuite) TestUnsubcribeWithPendingHandlersMarksDone(c *gc.C) {
 	wait := make(chan struct{})
-	mutex := sync.Mutex{}
-	var calls []pubsub.Topic
+	var calls []string
 	hub := pubsub.NewSimpleHub(nil)
-	var unsubscriber pubsub.Unsubscriber
+	var unsubscribe func()
 	var err error
-	unsubscriber = hub.Subscribe(topic, func(topic pubsub.Topic, data interface{}) {
+	unsubscribe = hub.Subscribe("topic", func(topic string, data interface{}) {
 		<-wait
-		mutex.Lock()
-		defer mutex.Unlock()
 		calls = append(calls, topic)
-		unsubscriber.Unsubscribe()
+		unsubscribe()
 	})
 	c.Assert(err, gc.IsNil)
 	var lastCall <-chan struct{}
 	for i := 0; i < 5; i++ {
-		lastCall = hub.Publish(topic, nil)
+		lastCall = hub.Publish("topic", nil)
 	}
 	// release the handlers
 	close(wait)
 
 	waitForMessageHandlingToBeComplete(c, lastCall)
 	// Only the first handler should execute as we unsubscribe in it.
-	c.Assert(calls, jc.DeepEquals, []pubsub.Topic{topic})
+	c.Assert(calls, jc.DeepEquals, []string{"topic"})
 }
 
 func (*SimpleHubSuite) TestSubscribeMissingHandler(c *gc.C) {
 	hub := pubsub.NewSimpleHub(nil)
-	unsubscriber := hub.Subscribe(topic, nil)
-	c.Assert(unsubscriber, gc.IsNil)
+	unsubscribe := hub.Subscribe("topic", nil)
+	c.Assert(unsubscribe, gc.NotNil)
+	// Calling it is fine.
+	unsubscribe()
 }
 
 func (*SimpleHubSuite) TestSubscribeMissingMatcher(c *gc.C) {
 	hub := pubsub.NewSimpleHub(nil)
-	unsubscriber := hub.Subscribe(nil, func(pubsub.Topic, interface{}) {})
-	c.Assert(unsubscriber, gc.IsNil)
+	unsubscribe := hub.SubscribeMatch(nil, func(string, interface{}) {})
+	c.Assert(unsubscribe, gc.NotNil)
+	// Calling it is fine.
+	unsubscribe()
 }
 
 func (*SimpleHubSuite) TestUnsubscribe(c *gc.C) {
 	var called bool
 	hub := pubsub.NewSimpleHub(nil)
-	sub := hub.Subscribe(topic, func(topic pubsub.Topic, data interface{}) {
+	unsub := hub.Subscribe("topic", func(topic string, data interface{}) {
 		called = true
 	})
-	sub.Unsubscribe()
-	done := hub.Publish(topic, nil)
+	unsub()
+	done := hub.Publish("topic", nil)
 
 	waitForMessageHandlingToBeComplete(c, done)
 	c.Assert(called, jc.IsFalse)
@@ -167,11 +157,11 @@ func (*SimpleHubSuite) TestSubscriberMultipleCallbacks(c *gc.C) {
 	thirdCalled := false
 
 	hub := pubsub.NewSimpleHub(nil)
-	hub.Subscribe(topic, func(pubsub.Topic, interface{}) { firstCalled = true })
-	hub.Subscribe(topic, func(pubsub.Topic, interface{}) { secondCalled = true })
-	hub.Subscribe(topic, func(pubsub.Topic, interface{}) { thirdCalled = true })
+	hub.Subscribe("topic", func(string, interface{}) { firstCalled = true })
+	hub.Subscribe("topic", func(string, interface{}) { secondCalled = true })
+	hub.Subscribe("topic", func(string, interface{}) { thirdCalled = true })
 
-	done := hub.Publish(topic, nil)
+	done := hub.Publish("topic", nil)
 
 	waitForMessageHandlingToBeComplete(c, done)
 	c.Check(firstCalled, jc.IsTrue)

--- a/structuredcallback.go
+++ b/structuredcallback.go
@@ -7,17 +7,16 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 )
 
 type structuredCallback struct {
-	logger     loggo.Logger
+	logger     Logger
 	marshaller Marshaller
 	callback   reflect.Value
 	dataType   reflect.Type
 }
 
-func newStructuredCallback(logger loggo.Logger, marshaller Marshaller, handler interface{}) (*structuredCallback, error) {
+func newStructuredCallback(logger Logger, marshaller Marshaller, handler interface{}) (*structuredCallback, error) {
 	rt, err := checkStructuredHandler(handler)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -31,7 +30,7 @@ func newStructuredCallback(logger loggo.Logger, marshaller Marshaller, handler i
 	}, nil
 }
 
-func (s *structuredCallback) handler(topic Topic, data interface{}) {
+func (s *structuredCallback) handler(topic string, data interface{}) {
 	// The data is always map[string]interface{}.
 	asMap := data.(map[string]interface{})
 	s.logger.Tracef("convert map to %v", s.dataType)
@@ -85,10 +84,10 @@ func checkStructuredHandler(handler interface{}) (reflect.Type, error) {
 		return nil, errors.NotValidf("expected 2 or 3 args, got %d, incorrect handler signature", t.NumIn())
 	}
 
-	var topic Topic
+	var topic string
 	var topicType = reflect.TypeOf(topic)
 	if t.In(0) != topicType {
-		return nil, errors.NotValidf("first arg should be a pubsub.Topic, incorrect handler signature")
+		return nil, errors.NotValidf("first arg should be a string, incorrect handler signature")
 	}
 
 	arg2 := t.In(1)

--- a/structuredhub_test.go
+++ b/structuredhub_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
@@ -15,9 +14,7 @@ import (
 	"github.com/juju/pubsub"
 )
 
-type StructuredHubSuite struct {
-	testing.LoggingCleanupSuite
-}
+type StructuredHubSuite struct{}
 
 var _ = gc.Suite(&StructuredHubSuite{})
 
@@ -64,42 +61,42 @@ func (*StructuredHubSuite) TestSubscribeHandler(c *gc.C) {
 			err:         "expected 2 or 3 args, got 4, incorrect handler signature not valid",
 		}, {
 			description: "simple hub handler function",
-			handler:     func(pubsub.Topic, interface{}) {},
+			handler:     func(string, interface{}) {},
 			err:         "second arg should be a structure or map\\[string\\]interface{} for data, incorrect handler signature not valid",
 		}, {
 			description: "bad return values in handler function",
-			handler:     func(pubsub.Topic, interface{}, error) error { return nil },
+			handler:     func(string, interface{}, error) error { return nil },
 			err:         "expected no return values, got 1, incorrect handler signature not valid",
 		}, {
 			description: "bad first arg",
-			handler:     func(string, map[string]interface{}, error) {},
-			err:         "first arg should be a pubsub.Topic, incorrect handler signature not valid",
+			handler:     func(int, map[string]interface{}, error) {},
+			err:         "first arg should be a string, incorrect handler signature not valid",
 		}, {
 			description: "bad second arg",
-			handler:     func(pubsub.Topic, string, error) {},
+			handler:     func(string, string, error) {},
 			err:         "second arg should be a structure or map\\[string\\]interface{} for data, incorrect handler signature not valid",
 		}, {
 			description: "bad third arg",
-			handler:     func(pubsub.Topic, map[string]interface{}, error) {},
+			handler:     func(string, map[string]interface{}, error) {},
 			err:         "data type of map\\[string\\]interface{} expects only 2 args, got 3, incorrect handler signature not valid",
 		}, {
 			description: "accept map[string]interface{}",
-			handler:     func(pubsub.Topic, map[string]interface{}) {},
+			handler:     func(string, map[string]interface{}) {},
 		}, {
 			description: "bad map[string]string",
-			handler:     func(pubsub.Topic, map[string]string, error) {},
+			handler:     func(string, map[string]string, error) {},
 			err:         "second arg should be a structure or map\\[string\\]interface{} for data, incorrect handler signature not valid",
 		}, {
 			description: "bad third arg",
-			handler:     func(pubsub.Topic, Emitter, bool) {},
+			handler:     func(string, Emitter, bool) {},
 			err:         "third arg should be error for deserialization errors, incorrect handler signature not valid",
 		}, {
 			description: "accept struct value",
-			handler:     func(pubsub.Topic, Emitter, error) {},
+			handler:     func(string, Emitter, error) {},
 		},
 	} {
 		c.Logf("test %d: %s", i, test.description)
-		sub, err := hub.Subscribe(pubsub.MatchAll, test.handler)
+		sub, err := hub.SubscribeMatch(pubsub.MatchAll, test.handler)
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)
 			c.Check(sub, gc.NotNil)
@@ -113,15 +110,15 @@ func (*StructuredHubSuite) TestSubscribeHandler(c *gc.C) {
 func (*StructuredHubSuite) TestPublishNil(c *gc.C) {
 	called := false
 	hub := pubsub.NewStructuredHub(nil)
-	sub, err := hub.Subscribe(topic, func(topic pubsub.Topic, data map[string]interface{}) {
+	unsub, err := hub.Subscribe("topic", func(topic string, data map[string]interface{}) {
 		c.Check(data, gc.NotNil)
 		c.Check(data, gc.HasLen, 0)
 		called = true
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	defer sub.Unsubscribe()
+	defer unsub()
 
-	done, err := hub.Publish(topic, nil)
+	done, err := hub.Publish("topic", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
@@ -130,7 +127,7 @@ func (*StructuredHubSuite) TestPublishNil(c *gc.C) {
 
 func (*StructuredHubSuite) TestBadPublish(c *gc.C) {
 	hub := pubsub.NewStructuredHub(nil)
-	done, err := hub.Publish(first, "hello")
+	done, err := hub.Publish("topic", "hello")
 	c.Check(done, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "unmarshalling: json: cannot unmarshal string into Go value of type map\\[string\\]interface {}")
 }
@@ -147,25 +144,25 @@ func (*StructuredHubSuite) TestPublishDeserialize(c *gc.C) {
 		mapCalled     bool
 	)
 	hub := pubsub.NewStructuredHub(nil)
-	sub, err := hub.Subscribe(topic, func(topic pubsub.Topic, data JustOrigin, err error) {
+	unsub, err := hub.Subscribe("topic", func(topic string, data JustOrigin, err error) {
 		c.Check(err, jc.ErrorIsNil)
-		c.Check(topic, gc.Equals, topic)
+		c.Check(topic, gc.Equals, "topic")
 		c.Check(data.Origin, gc.Equals, source.Origin)
 		originCalled = true
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	defer sub.Unsubscribe()
-	sub, err = hub.Subscribe(topic, func(topic pubsub.Topic, data MessageID, err error) {
+	defer unsub()
+	unsub, err = hub.Subscribe("topic", func(topic string, data MessageID, err error) {
 		c.Check(err, jc.ErrorIsNil)
-		c.Check(topic, gc.Equals, topic)
+		c.Check(topic, gc.Equals, "topic")
 		c.Check(data.Message, gc.Equals, source.Message)
 		c.Check(data.Key, gc.Equals, source.ID)
 		messageCalled = true
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	defer sub.Unsubscribe()
-	sub, err = hub.Subscribe(topic, func(topic pubsub.Topic, data map[string]interface{}) {
-		c.Check(topic, gc.Equals, topic)
+	defer unsub()
+	unsub, err = hub.Subscribe("topic", func(topic string, data map[string]interface{}) {
+		c.Check(topic, gc.Equals, "topic")
 		c.Check(data, jc.DeepEquals, map[string]interface{}{
 			"origin":  "test",
 			"message": "hello world",
@@ -174,8 +171,8 @@ func (*StructuredHubSuite) TestPublishDeserialize(c *gc.C) {
 		mapCalled = true
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	defer sub.Unsubscribe()
-	done, err := hub.Publish(topic, source)
+	defer unsub()
+	done, err := hub.Publish("topic", source)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
@@ -197,25 +194,25 @@ func (*StructuredHubSuite) TestPublishMap(c *gc.C) {
 		mapCalled     bool
 	)
 	hub := pubsub.NewStructuredHub(nil)
-	sub, err := hub.Subscribe(topic, func(topic pubsub.Topic, data JustOrigin, err error) {
+	unsub, err := hub.Subscribe("topic", func(topic string, data JustOrigin, err error) {
 		c.Check(err, jc.ErrorIsNil)
-		c.Check(topic, gc.Equals, topic)
+		c.Check(topic, gc.Equals, "topic")
 		c.Check(data.Origin, gc.Equals, source["origin"])
 		originCalled = true
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	defer sub.Unsubscribe()
-	sub, err = hub.Subscribe(topic, func(topic pubsub.Topic, data MessageID, err error) {
+	defer unsub()
+	unsub, err = hub.Subscribe("topic", func(topic string, data MessageID, err error) {
 		c.Check(err, jc.ErrorIsNil)
-		c.Check(topic, gc.Equals, topic)
+		c.Check(topic, gc.Equals, "topic")
 		c.Check(data.Message, gc.Equals, source["message"])
 		c.Check(data.Key, gc.Equals, source["id"])
 		messageCalled = true
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	defer sub.Unsubscribe()
-	sub, err = hub.Subscribe(topic, func(topic pubsub.Topic, data map[string]interface{}) {
-		c.Check(topic, gc.Equals, topic)
+	defer unsub()
+	unsub, err = hub.Subscribe("topic", func(topic string, data map[string]interface{}) {
+		c.Check(topic, gc.Equals, "topic")
 		c.Check(data, jc.DeepEquals, map[string]interface{}{
 			"origin":  "test",
 			"message": "hello world",
@@ -224,8 +221,8 @@ func (*StructuredHubSuite) TestPublishMap(c *gc.C) {
 		mapCalled = true
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	defer sub.Unsubscribe()
-	done, err := hub.Publish(topic, source)
+	defer unsub()
+	done, err := hub.Publish("topic", source)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
@@ -243,15 +240,15 @@ func (*StructuredHubSuite) TestPublishDeserializeError(c *gc.C) {
 	}
 	called := false
 	hub := pubsub.NewStructuredHub(nil)
-	sub, err := hub.Subscribe(topic, func(topic pubsub.Topic, data BadID, err error) {
+	unsub, err := hub.Subscribe("topic", func(topic string, data BadID, err error) {
 		c.Check(err.Error(), gc.Equals, "unmarshalling data: json: cannot unmarshal number into Go value of type string")
-		c.Check(topic, gc.Equals, topic)
+		c.Check(topic, gc.Equals, "topic")
 		c.Check(data.ID, gc.Equals, "")
 		called = true
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	defer sub.Unsubscribe()
-	done, err := hub.Publish(topic, source)
+	defer unsub()
+	done, err := hub.Publish("topic", source)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
@@ -279,8 +276,8 @@ func (*StructuredHubSuite) TestYAMLMarshalling(c *gc.C) {
 		&pubsub.StructuredHubConfig{
 			Marshaller: &yamlMarshaller{},
 		})
-	sub, err := hub.Subscribe(topic, func(topic pubsub.Topic, data map[string]interface{}) {
-		c.Check(topic, gc.Equals, topic)
+	unsub, err := hub.Subscribe("topic", func(topic string, data map[string]interface{}) {
+		c.Check(topic, gc.Equals, "topic")
 		c.Check(data, jc.DeepEquals, map[string]interface{}{
 			"origin":  "test",
 			"message": "hello world",
@@ -289,9 +286,9 @@ func (*StructuredHubSuite) TestYAMLMarshalling(c *gc.C) {
 		called = true
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	defer sub.Unsubscribe()
+	defer unsub()
 
-	done, err := hub.Publish(topic, source)
+	done, err := hub.Publish("topic", source)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
@@ -312,21 +309,21 @@ func (*StructuredHubSuite) TestAnnotations(c *gc.C) {
 				"origin": origin,
 			},
 		})
-	sub, err := hub.Subscribe(topic, func(topic pubsub.Topic, data Emitter, err error) {
+	unsub, err := hub.Subscribe("topic", func(topic string, data Emitter, err error) {
 		c.Check(err, jc.ErrorIsNil)
-		c.Check(topic, gc.Equals, topic)
+		c.Check(topic, gc.Equals, "topic")
 		obtained = append(obtained, data.Origin)
 		c.Check(data.Message, gc.Equals, source.Message)
 		c.Check(data.ID, gc.Equals, source.ID)
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	defer sub.Unsubscribe()
-	done, err := hub.Publish(topic, source)
+	defer unsub()
+	done, err := hub.Publish("topic", source)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
 	source.Origin = "other"
-	done, err = hub.Publish(topic, source)
+	done, err = hub.Publish("topic", source)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
@@ -347,17 +344,17 @@ func (*StructuredHubSuite) TestPostProcess(c *gc.C) {
 				return in, nil
 			},
 		})
-	unsub, err := hub.Subscribe(topic, func(t pubsub.Topic, data map[string]interface{}) {
+	unsub, err := hub.Subscribe("topic", func(_ string, data map[string]interface{}) {
 		values = append(values, data["counter"].(int))
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	defer unsub.Unsubscribe()
+	defer unsub()
 
-	_, err = hub.Publish(topic, JustOrigin{"origin"})
+	_, err = hub.Publish("topic", JustOrigin{"origin"})
 	c.Assert(err, gc.ErrorMatches, "bad")
-	_, err = hub.Publish(topic, JustOrigin{"origin"})
+	_, err = hub.Publish("topic", JustOrigin{"origin"})
 	c.Assert(err, jc.ErrorIsNil)
-	done, err := hub.Publish(topic, JustOrigin{"origin"})
+	done, err := hub.Publish("topic", JustOrigin{"origin"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
@@ -370,14 +367,14 @@ type Worker struct {
 	fromMap    []string
 }
 
-func (w *Worker) subMessage(topic pubsub.Topic, data MessageID, err error) {
+func (w *Worker) subMessage(topic string, data MessageID, err error) {
 	w.m.Lock()
 	defer w.m.Unlock()
 
 	w.fromStruct = append(w.fromStruct, data.Message)
 }
 
-func (w *Worker) subData(topic pubsub.Topic, data map[string]interface{}) {
+func (w *Worker) subData(topic string, data map[string]interface{}) {
 	w.m.Lock()
 	defer w.m.Unlock()
 
@@ -388,12 +385,12 @@ func (w *Worker) subData(topic pubsub.Topic, data map[string]interface{}) {
 func (*StructuredHubSuite) TestMultipleSubscribersSingleInstance(c *gc.C) {
 	hub := pubsub.NewStructuredHub(nil)
 	w := &Worker{}
-	sub, err := hub.Subscribe(pubsub.MatchAll, w.subData)
+	unsub, err := hub.SubscribeMatch(pubsub.MatchAll, w.subData)
 	c.Assert(err, jc.ErrorIsNil)
-	defer sub.Unsubscribe()
-	sub, err = hub.Subscribe(pubsub.MatchAll, w.subMessage)
+	defer unsub()
+	unsub, err = hub.SubscribeMatch(pubsub.MatchAll, w.subMessage)
 	c.Assert(err, jc.ErrorIsNil)
-	defer sub.Unsubscribe()
+	defer unsub()
 
 	message := "a message"
 	done, err := hub.Publish("foo", MessageID{Message: message})

--- a/subscriber.go
+++ b/subscriber.go
@@ -6,23 +6,15 @@ package pubsub
 import (
 	"sync"
 
-	"github.com/juju/loggo"
 	"github.com/juju/utils/deque"
 )
-
-// Unsubscriber provides a way to stop receiving handler callbacks.
-// Unsubscribing from a hub will also mark any pending notifications as done,
-// and the handler will not be called for them.
-type Unsubscriber interface {
-	Unsubscribe()
-}
 
 type subscriber struct {
 	id int
 
-	logger       loggo.Logger
-	topicMatcher TopicMatcher
-	handler      func(topic Topic, data interface{})
+	logger       Logger
+	topicMatcher func(topic string) bool
+	handler      func(topic string, data interface{})
 
 	mutex   sync.Mutex
 	pending *deque.Deque
@@ -31,7 +23,7 @@ type subscriber struct {
 	done    chan struct{}
 }
 
-func newSubscriber(matcher TopicMatcher, handler func(Topic, interface{}), logger loggo.Logger) *subscriber {
+func newSubscriber(matcher func(topic string) bool, handler func(string, interface{}), logger Logger) *subscriber {
 	// A closed channel is used to provide an immediate route through a select
 	// call in the loop function.
 	closed := make(chan struct{})


### PR DESCRIPTION
Hindsight is a wonderful thing. When trying to use the pubsub package in Juju itself, and defining interfaces in packages that required a Hub, it quickly became apparent that the pubsub.Topic and pubsub.Unsubscriber types were a hinderance to simple mocking.

This branch changes the topic back to being a simple string, and changes the Subscribe method to match the topic exactly, and provides a SubscribeMatch method that allows the specifying of an function that can match the topic.

This branch also removes the hard dependency on loggo, instead allowing the caller to pass in anything that supports the required Logger interface.