### PR TITLE
Make creating a subscriber only log at trace level

### DIFF
--- a/subscriber.go
+++ b/subscriber.go
@@ -38,7 +38,7 @@ func newSubscriber(matcher func(topic string) bool, handler func(string, interfa
 		closed:       closed,
 	}
 	go sub.loop()
-	sub.logger.Debugf("created subscriber %p for %v", sub, matcher)
+	sub.logger.Tracef("created subscriber %p for %v", sub, matcher)
 	return sub
 }
 


### PR DESCRIPTION
Now that raft leases use a request/response pattern over the hub, there are far more subscriptions being created - one for each request, to get the response, at least once per controller per second. Make this trace so it doesn't spam the debug logs.