### PR TITLE
Add a multiplexer for the simple hub.

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -8,7 +8,12 @@ var (
 	MultiUnsubscribeTestHook = &multiUnsubscribeTestHook
 )
 
-// Exported to test matching.
+// MultiplexerMatch exported to test matching.
 func MultiplexerMatch(m Multiplexer, topic string) bool {
 	return m.(*multiplexer).match(topic)
+}
+
+// SimpleMultiplexerMatch exported to test matching.
+func SimpleMultiplexerMatch(m SimpleMultiplexer, topic string) bool {
+	return m.(*simpleMultiplexer).match(topic)
 }

--- a/simplemultiplexer.go
+++ b/simplemultiplexer.go
@@ -1,0 +1,106 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package pubsub
+
+import (
+	"sync"
+)
+
+// TODO: refactor Multiplexer type for structured hub to be based off this type.
+
+// SimpleMultiplexer allows multiple subscriptions to be made sharing a single
+// message queue from the hub. This means that all the messages for the
+// various subscriptions are called back in the order that the messages were
+// published. If more than one handler is added to the SimpleMultiplexer that
+// matches any given topic, the handlers are called back one after the other
+// in the order that they were added.
+type SimpleMultiplexer interface {
+	Add(topic string, handler func(string, interface{}))
+	AddMatch(matcher func(string) bool, handler func(string, interface{}))
+	Unsubscribe()
+}
+
+type simpleElement struct {
+	matcher func(string) bool
+	handler func(string, interface{})
+}
+
+type simpleMultiplexer struct {
+	logger       Logger
+	mu           sync.Mutex
+	outputs      []simpleElement
+	unsubscriber func()
+}
+
+// NewMultiplexer creates a new multiplexer for the hub and subscribes it.
+// Unsubscribing the multiplexer stops calls for all handlers added.
+func (h *SimpleHub) NewMultiplexer() SimpleMultiplexer {
+	mp := &simpleMultiplexer{logger: h.logger}
+	unsub := h.SubscribeMatch(mp.match, mp.callback)
+	mp.unsubscriber = unsub
+	return mp
+}
+
+// Add a handler for a specific topic.
+func (m *simpleMultiplexer) Add(topic string, handler func(string, interface{})) {
+	m.AddMatch(equalTopic(topic), handler)
+}
+
+// AddMatch adds another handler for any topic that matches the matcher.
+func (m *simpleMultiplexer) AddMatch(matcher func(string) bool, handler func(string, interface{})) {
+	// This mimics the behaviour of the simple hub itself.
+	if handler == nil || matcher == nil {
+		// It is safe but useless.
+		return
+	}
+	m.mu.Lock()
+	m.outputs = append(m.outputs, simpleElement{matcher: matcher, handler: handler})
+	m.mu.Unlock()
+}
+
+// Unsubscribe the multiplexer from the simple hub.
+func (m *simpleMultiplexer) Unsubscribe() {
+	m.mu.Lock()
+	unsubscriber := m.unsubscriber
+	m.unsubscriber = nil
+	m.mu.Unlock()
+
+	if multiUnsubscribeTestHook != nil {
+		multiUnsubscribeTestHook()
+	}
+
+	if unsubscriber != nil {
+		unsubscriber()
+	}
+}
+
+func (m *simpleMultiplexer) callback(topic string, data interface{}) {
+	// Since the callback functions have arbitrary code, don't hold the
+	// mutex for the duration of the calls.
+	m.mu.Lock()
+	outputs := make([]simpleElement, len(m.outputs))
+	copy(outputs, m.outputs)
+	m.mu.Unlock()
+
+	for _, element := range outputs {
+		if element.matcher(topic) {
+			element.handler(topic, data)
+		}
+	}
+}
+
+// If any of the topic matchers added for the handlers match the topic, the
+// simpleMultiplexer matches.
+func (m *simpleMultiplexer) match(topic string) bool {
+	// Here we explicitly don't make a copy of the outputs as the match
+	// function is going to be called much more often than the callback func.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, element := range m.outputs {
+		if element.matcher(topic) {
+			return true
+		}
+	}
+	return false
+}

--- a/simplemultiplexer_test.go
+++ b/simplemultiplexer_test.go
@@ -1,0 +1,165 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package pubsub_test
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/pubsub"
+)
+
+type SimpleMultiplexerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&SimpleMultiplexerSuite{})
+
+func (*SimpleMultiplexerSuite) TestNewMultiplexerStructuredHub(c *gc.C) {
+	hub := pubsub.NewSimpleHub(nil)
+	multi := hub.NewMultiplexer()
+	defer multi.Unsubscribe()
+	c.Check(multi, gc.NotNil)
+}
+
+func (*SimpleMultiplexerSuite) TestMatcher(c *gc.C) {
+	hub := pubsub.NewSimpleHub(nil)
+	multi := hub.NewMultiplexer()
+	defer multi.Unsubscribe()
+
+	noopFunc := func(string, interface{}) {}
+	multi.Add(first, noopFunc)
+	multi.AddMatch(pubsub.MatchRegexp("second.*"), noopFunc)
+
+	c.Check(pubsub.SimpleMultiplexerMatch(multi, first), jc.IsTrue)
+	c.Check(pubsub.SimpleMultiplexerMatch(multi, firstdot), jc.IsFalse)
+	c.Check(pubsub.SimpleMultiplexerMatch(multi, second), jc.IsTrue)
+	c.Check(pubsub.SimpleMultiplexerMatch(multi, space), jc.IsFalse)
+}
+
+func (*SimpleMultiplexerSuite) TestCallback(c *gc.C) {
+	source := &Emitter{
+		Origin:  "test",
+		Message: "hello world",
+		ID:      42,
+	}
+	var (
+		topic         = "callback.topic"
+		originCalled  bool
+		messageCalled bool
+	)
+	hub := pubsub.NewSimpleHub(nil)
+	multi := hub.NewMultiplexer()
+	defer multi.Unsubscribe()
+
+	multi.Add(topic, func(top string, data interface{}) {
+		c.Check(top, gc.Equals, topic)
+		c.Check(data, jc.DeepEquals, source)
+		originCalled = true
+	})
+	multi.Add(second, func(topic string, data interface{}) {
+		c.Fail()
+		messageCalled = true
+	})
+	done := hub.Publish(topic, source)
+
+	waitForMessageHandlingToBeComplete(c, done)
+	c.Check(originCalled, jc.IsTrue)
+	c.Check(messageCalled, jc.IsFalse)
+}
+
+func (*SimpleMultiplexerSuite) TestCallbackCanPublish(c *gc.C) {
+	var (
+		topic         = "callback.topic"
+		source        = "magic"
+		originCalled  bool
+		messageCalled bool
+		nestedPublish <-chan struct{}
+	)
+	hub := pubsub.NewSimpleHub(nil)
+	multi := hub.NewMultiplexer()
+	defer multi.Unsubscribe()
+
+	multi.Add(topic, func(top string, data interface{}) {
+		c.Check(top, gc.Equals, topic)
+		c.Check(data, gc.Equals, source)
+		originCalled = true
+
+		nestedPublish = hub.Publish(second, "new message")
+	})
+	multi.Add(second, func(topic string, data interface{}) {
+		c.Check(data, gc.Equals, "new message")
+		messageCalled = true
+	})
+	done := hub.Publish(topic, source)
+
+	waitForMessageHandlingToBeComplete(c, done)
+	waitForMessageHandlingToBeComplete(c, nestedPublish)
+	c.Check(originCalled, jc.IsTrue)
+	c.Check(messageCalled, jc.IsTrue)
+}
+
+func (s *SimpleMultiplexerSuite) TestUnsubscribeWhileMatch(c *gc.C) {
+	// The race we are trying do deal with is this:
+	// Publish is called, it acquires underlying mutex on hub
+	// Unsubscribe is called, it acquires the mutex on the multiplexer
+	// and awaits the mutex on the hub
+	// Publish proceeds and calls match on the multiplexer which wants
+	// the multiplexer mutex
+	// = deadlock
+
+	publishBlock := make(chan struct{})
+	publishReady := make(chan struct{})
+	unsubBlock := make(chan struct{})
+	unsubReady := make(chan struct{})
+
+	s.PatchValue(pubsub.PrePublishTestHook, func() {
+		close(publishReady)
+		<-publishBlock
+	})
+	s.PatchValue(pubsub.MultiUnsubscribeTestHook, func() {
+		close(unsubReady)
+		<-unsubBlock
+	})
+
+	hub := pubsub.NewSimpleHub(nil)
+	multi := hub.NewMultiplexer()
+
+	multi.Add("a subject", func(string, interface{}) {})
+
+	go func() {
+		hub.Publish("test", "a value")
+	}()
+
+	select {
+	case <-time.After(testing.LongWait):
+		c.Errorf("publish not called")
+	case <-publishReady:
+	}
+
+	unsubscribed := make(chan struct{})
+	go func() {
+		multi.Unsubscribe()
+		close(unsubscribed)
+	}()
+
+	select {
+	case <-time.After(testing.LongWait):
+		c.Errorf("unsubscribe not called")
+	case <-unsubReady:
+	}
+
+	// Now both functions are in the right place, let them continue.
+	close(publishBlock)
+	close(unsubBlock)
+
+	select {
+	case <-time.After(testing.LongWait):
+		c.Errorf("unsubscribe blocked")
+	case <-unsubscribed:
+	}
+}


### PR DESCRIPTION
Takes the existing multiplexer and makes it work for the simple hub.

Left a TODO to refactor the structured hub's multiplexer to be based on the simple one. 