### PR TITLE
Prevent publish leaking goroutines

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -4,6 +4,7 @@
 package pubsub_test
 
 import (
+	"context"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -27,7 +28,7 @@ func (*BenchmarkSuite) BenchmarkStructuredNoConversions(c *gc.C) {
 	defer unsub()
 	failedCount := 0
 	for i := 0; i < c.N; i++ {
-		done, err := hub.Publish(topic, nil)
+		done, err := hub.Publish(context.TODO(), topic, nil)
 		c.Assert(err, jc.ErrorIsNil)
 
 		select {
@@ -57,7 +58,7 @@ func (*BenchmarkSuite) BenchmarkStructuredSerialize(c *gc.C) {
 		ID:      42,
 	}
 	for i := 0; i < c.N; i++ {
-		done, err := hub.Publish(topic, data)
+		done, err := hub.Publish(context.TODO(), topic, data)
 		c.Assert(err, jc.ErrorIsNil)
 
 		select {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,18 @@
+module github.com/juju/pubsub
+
+go 1.14
+
+require (
+	github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c
+	github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18
+	github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9
+	github.com/juju/retry v0.0.0-20151029024821-62c620325291
+	github.com/juju/testing v0.0.0-20180807044555-c84dd6ba038a
+	github.com/juju/utils v0.0.0-20180424094159-2000ea4ff043
+	github.com/juju/version v0.0.0-20161031051906-1f41e27e54f2
+	golang.org/x/crypto v0.0.0-20180214000028-650f4a345ab4
+	golang.org/x/net v0.0.0-20180406214816-61147c48b25b
+	gopkg.in/check.v1 v1.0.0-20160105164936-4f90aeace3a2
+	gopkg.in/mgo.v2 v2.0.0-20160818015218-f2b6f6c918c4
+	gopkg.in/yaml.v2 v2.0.0-20170712054546-1be3d31502d6
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c/go.mod h1:Ep+c0vnxsgmmTtsMibPgEEleZyi0b4uVvyzJ+8ka9EI=
+github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
+github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
+github.com/juju/retry v0.0.0-20151029024821-62c620325291/go.mod h1:OohPQGsr4pnxwD5YljhQ+TZnuVRYpa5irjugL1Yuif4=
+github.com/juju/testing v0.0.0-20180807044555-c84dd6ba038a h1:dhnWDfRjO/h2XFBj/n3qm+wGjHm8/UqLSOk9GhZc+P0=
+github.com/juju/testing v0.0.0-20180807044555-c84dd6ba038a/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
+github.com/juju/utils v0.0.0-20180424094159-2000ea4ff043 h1:kjdsJcIYzmK2k4X2yVCi5Nip6sGoAuc7CLbp+qQnQUM=
+github.com/juju/utils v0.0.0-20180424094159-2000ea4ff043/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
+github.com/juju/version v0.0.0-20161031051906-1f41e27e54f2/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
+golang.org/x/crypto v0.0.0-20180214000028-650f4a345ab4 h1:OfaUle5HH9Y0obNU74mlOZ/Igdtwi3eGOKcljJsTnbw=
+golang.org/x/crypto v0.0.0-20180214000028-650f4a345ab4/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/net v0.0.0-20180406214816-61147c48b25b h1:7rskAFQwNXGW6AD8E/6y0LDHW5mT9rsLD7ViLVFfh5w=
+golang.org/x/net v0.0.0-20180406214816-61147c48b25b/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+gopkg.in/check.v1 v1.0.0-20160105164936-4f90aeace3a2/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/mgo.v2 v2.0.0-20160818015218-f2b6f6c918c4/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
+gopkg.in/yaml.v2 v2.0.0-20170712054546-1be3d31502d6/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/multiplexer_test.go
+++ b/multiplexer_test.go
@@ -4,6 +4,7 @@
 package pubsub_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/testing"
@@ -155,7 +156,7 @@ func (*MultiplexerHubSuite) TestCallback(c *gc.C) {
 		mapCalled = true
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	done, err := hub.Publish(topic, source)
+	done, err := hub.Publish(context.TODO(), topic, source)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
@@ -175,7 +176,7 @@ func (*MultiplexerHubSuite) TestCallbackCanPublish(c *gc.C) {
 		originCalled  bool
 		messageCalled bool
 		mapCalled     bool
-		nestedPublish <-chan struct{}
+		nestedPublish <-chan error
 	)
 	hub := pubsub.NewStructuredHub(nil)
 	multi, err := hub.NewMultiplexer()
@@ -188,9 +189,10 @@ func (*MultiplexerHubSuite) TestCallbackCanPublish(c *gc.C) {
 		c.Check(data.Origin, gc.Equals, source.Origin)
 		originCalled = true
 
-		nestedPublish, err = hub.Publish(second, MessageID{
+		nestedPublish, err = hub.Publish(context.TODO(), second, MessageID{
 			Message: "new message",
 		})
+		c.Check(err, jc.ErrorIsNil)
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = multi.Add(second, func(topic string, data MessageID, err error) {
@@ -212,7 +214,7 @@ func (*MultiplexerHubSuite) TestCallbackCanPublish(c *gc.C) {
 		mapCalled = true
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	done, err := hub.Publish(topic, source)
+	done, err := hub.Publish(context.TODO(), topic, source)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
@@ -253,7 +255,7 @@ func (s *MultiplexerHubSuite) TestUnsubscribeWhileMatch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	go func() {
-		hub.Publish("test", map[string]interface{}{})
+		hub.Publish(context.TODO(), "test", map[string]interface{}{})
 	}()
 
 	select {

--- a/simplemultiplexer_test.go
+++ b/simplemultiplexer_test.go
@@ -4,6 +4,7 @@
 package pubsub_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/testing"
@@ -65,7 +66,7 @@ func (*SimpleMultiplexerSuite) TestCallback(c *gc.C) {
 		c.Fail()
 		messageCalled = true
 	})
-	done := hub.Publish(topic, source)
+	done := hub.Publish(context.TODO(), topic, source)
 
 	waitForMessageHandlingToBeComplete(c, done)
 	c.Check(originCalled, jc.IsTrue)
@@ -78,7 +79,7 @@ func (*SimpleMultiplexerSuite) TestCallbackCanPublish(c *gc.C) {
 		source        = "magic"
 		originCalled  bool
 		messageCalled bool
-		nestedPublish <-chan struct{}
+		nestedPublish <-chan error
 	)
 	hub := pubsub.NewSimpleHub(nil)
 	multi := hub.NewMultiplexer()
@@ -89,13 +90,13 @@ func (*SimpleMultiplexerSuite) TestCallbackCanPublish(c *gc.C) {
 		c.Check(data, gc.Equals, source)
 		originCalled = true
 
-		nestedPublish = hub.Publish(second, "new message")
+		nestedPublish = hub.Publish(context.TODO(), second, "new message")
 	})
 	multi.Add(second, func(topic string, data interface{}) {
 		c.Check(data, gc.Equals, "new message")
 		messageCalled = true
 	})
-	done := hub.Publish(topic, source)
+	done := hub.Publish(context.TODO(), topic, source)
 
 	waitForMessageHandlingToBeComplete(c, done)
 	waitForMessageHandlingToBeComplete(c, nestedPublish)
@@ -132,7 +133,7 @@ func (s *SimpleMultiplexerSuite) TestUnsubscribeWhileMatch(c *gc.C) {
 	multi.Add("a subject", func(string, interface{}) {})
 
 	go func() {
-		hub.Publish("test", "a value")
+		hub.Publish(context.TODO(), "test", "a value")
 	}()
 
 	select {

--- a/structuredhub.go
+++ b/structuredhub.go
@@ -4,6 +4,7 @@
 package pubsub
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 
@@ -109,7 +110,7 @@ func NewStructuredHub(config *StructuredHubConfig) *StructuredHub {
 //
 // The channel return value is closed when all the subscribers have been
 // notified of the event.
-func (h *StructuredHub) Publish(topic string, data interface{}) (<-chan struct{}, error) {
+func (h *StructuredHub) Publish(ctx context.Context, topic string, data interface{}) (<-chan error, error) {
 	if data == nil {
 		data = make(map[string]interface{})
 	}
@@ -129,7 +130,7 @@ func (h *StructuredHub) Publish(topic string, data interface{}) (<-chan struct{}
 		}
 	}
 	h.hub.logger.Tracef("publish %q: %#v", topic, asMap)
-	return h.hub.Publish(topic, asMap), nil
+	return h.hub.Publish(ctx, topic, asMap), nil
 }
 
 func (h *StructuredHub) toStringMap(data interface{}) (map[string]interface{}, error) {

--- a/structuredhub_test.go
+++ b/structuredhub_test.go
@@ -4,6 +4,7 @@
 package pubsub_test
 
 import (
+	"context"
 	"errors"
 	"sync"
 
@@ -118,7 +119,7 @@ func (*StructuredHubSuite) TestPublishNil(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer unsub()
 
-	done, err := hub.Publish("topic", nil)
+	done, err := hub.Publish(context.TODO(), "topic", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
@@ -127,7 +128,7 @@ func (*StructuredHubSuite) TestPublishNil(c *gc.C) {
 
 func (*StructuredHubSuite) TestBadPublish(c *gc.C) {
 	hub := pubsub.NewStructuredHub(nil)
-	done, err := hub.Publish("topic", "hello")
+	done, err := hub.Publish(context.TODO(), "topic", "hello")
 	c.Check(done, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "unmarshalling: json: cannot unmarshal string into Go value of type map\\[string\\]interface {}")
 }
@@ -172,7 +173,7 @@ func (*StructuredHubSuite) TestPublishDeserialize(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer unsub()
-	done, err := hub.Publish("topic", source)
+	done, err := hub.Publish(context.TODO(), "topic", source)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
@@ -222,7 +223,7 @@ func (*StructuredHubSuite) TestPublishMap(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer unsub()
-	done, err := hub.Publish("topic", source)
+	done, err := hub.Publish(context.TODO(), "topic", source)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
@@ -254,7 +255,7 @@ func (*StructuredHubSuite) TestPublishDeserializeError(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer unsub()
-	done, err := hub.Publish("topic", source)
+	done, err := hub.Publish(context.TODO(), "topic", source)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
@@ -294,7 +295,7 @@ func (*StructuredHubSuite) TestYAMLMarshalling(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer unsub()
 
-	done, err := hub.Publish("topic", source)
+	done, err := hub.Publish(context.TODO(), "topic", source)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
@@ -324,12 +325,12 @@ func (*StructuredHubSuite) TestAnnotations(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer unsub()
-	done, err := hub.Publish("topic", source)
+	done, err := hub.Publish(context.TODO(), "topic", source)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
 	source.Origin = "other"
-	done, err = hub.Publish("topic", source)
+	done, err = hub.Publish(context.TODO(), "topic", source)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
@@ -356,11 +357,11 @@ func (*StructuredHubSuite) TestPostProcess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer unsub()
 
-	_, err = hub.Publish("topic", JustOrigin{"origin"})
+	_, err = hub.Publish(context.TODO(), "topic", JustOrigin{"origin"})
 	c.Assert(err, gc.ErrorMatches, "bad")
-	_, err = hub.Publish("topic", JustOrigin{"origin"})
+	_, err = hub.Publish(context.TODO(), "topic", JustOrigin{"origin"})
 	c.Assert(err, jc.ErrorIsNil)
-	done, err := hub.Publish("topic", JustOrigin{"origin"})
+	done, err := hub.Publish(context.TODO(), "topic", JustOrigin{"origin"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)
@@ -399,7 +400,7 @@ func (*StructuredHubSuite) TestMultipleSubscribersSingleInstance(c *gc.C) {
 	defer unsub()
 
 	message := "a message"
-	done, err := hub.Publish("foo", MessageID{Message: message})
+	done, err := hub.Publish(context.TODO(), "foo", MessageID{Message: message})
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForMessageHandlingToBeComplete(c, done)


### PR DESCRIPTION
The following allows the canceling of a WaitGroup. When a publish
call is called, it enqueues the information onto a subscriber. This
includes the WaitGroup.Done method. If the Done method is never called,
the done channel is never closed and then goroutine is never exited.
This manifests itself as leaking gorountines. Putting back pressure onto the 
call site of Publish call.

The code changes are as follows:

 - Allow the passing in of a context. That context can be a cancellable or a 
   timeout context. When the context done channel is invoked we return out 
   and exit out of the goroutine. 
 - The resulting channel was changed from a struct to an error so that it's 
    possible to be notified if the context was canceled.

This should prevent the leaking of the goroutines. The subscriber-side
should then ensure that they also handle cancellations.

```go
ctx, cancel := context.WithTimeout(context.TODO(), time.Second*5)
defer cancel()

done, err := hub.Publish(ctx, "topic", nil)
if err != nil {
    return errors.Trace(err)
}
select {
case err := <-done:
    if err != nil {
        return errors.Trace(err)
    }
// we shouldn't need a time.After here, as the context handles that.
}

...

```

The problem with this approach is that the subscriber is still handling the
callback and still has a reference to the original WaitGroup. When does that
get cleaned up in a real-world solution is anybody's guess (think deadlock!).

------

Alternatively, we could make Publish fire and forget, by changing the semantics 
of Publish. Instead, we could say, every Publish that has been notified onto a
subscriber is done. However long a subscriber takes to call the handler callback
isn't a concern of the Publisher. The publish just wants to be notified that everything
was enqueued.
If you then want to know if everything was sent (over the wire for an API request), a 
message back over the same hub to the callee of Publish should be done. Similar
to Ping/Pong.

```go
// First setup a callback
hub.Subscribe("topic-pong", func(topic string, data interface{}) {
    // handle the result of the pong.
})

// Send the message
done, err := hub.Publish("topic-ping", nil)
if err != nil {
    return errors.Trace(err)
}
select {
case <-done:
    return nil
case <- time.After(time.Second*5):
    return errors.Errorf("something went wrong")
}
```