### PR TITLE
Metrics: Expose underlying queue status

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -6,6 +6,7 @@ package pubsub
 var (
 	PrePublishTestHook       = &prePublishTestHook
 	MultiUnsubscribeTestHook = &multiUnsubscribeTestHook
+	GetFunctionName          = getFunctionName
 )
 
 // MultiplexerMatch exported to test matching.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/juju/pubsub/v2
 go 1.14
 
 require (
+	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c
 	github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18
 	github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c h1:3UvYABOQRhJAApj9MdCN+Ydv841ETSoy6xLzdmmr/9A=
+github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c/go.mod h1:Ep+c0vnxsgmmTtsMibPgEEleZyi0b4uVvyzJ+8ka9EI=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=

--- a/logger.go
+++ b/logger.go
@@ -6,11 +6,13 @@ package pubsub
 // Logger represents methods called by this package to a logging
 // system.
 type Logger interface {
+	Errorf(format string, values ...interface{})
 	Debugf(format string, values ...interface{})
 	Tracef(format string, values ...interface{})
 }
 
 type noOpLogger struct{}
 
+func (noOpLogger) Errorf(format string, values ...interface{}) {}
 func (noOpLogger) Debugf(format string, values ...interface{}) {}
 func (noOpLogger) Tracef(format string, values ...interface{}) {}

--- a/metrics.go
+++ b/metrics.go
@@ -22,23 +22,23 @@ type Metrics interface {
 	// Enqueued metric increments the number of messages a subscriber has
 	// currently. This can be used to see if a subscriber has a backlog of
 	// messages pilling up.
-	Enqueued(index int)
+	Enqueued(ident string)
 
 	// Dequeued metric decrements the message count once the subscriber has
 	// in the pending queue. This doesn't tell you if the message was consumed
 	// via the callback, or how long it took.
-	Dequeued(index int)
+	Dequeued(ident string)
 
-	// Consumed metric identifies the number of consumed messages the subscriber
+	// Consumed metric increments the number of consumed messages the subscriber
 	// has consumed since a message was enqueued.
-	Consumed(index int, duration time.Duration)
+	Consumed(ident string, duration time.Duration)
 }
 
 type noOpMetrics struct{}
 
-func (noOpMetrics) Subscribed()                                {}
-func (noOpMetrics) Unsubscribed()                              {}
-func (noOpMetrics) Published(topic string)                     {}
-func (noOpMetrics) Enqueued(index int)                         {}
-func (noOpMetrics) Dequeued(index int)                         {}
-func (noOpMetrics) Consumed(index int, duration time.Duration) {}
+func (noOpMetrics) Subscribed()                                   {}
+func (noOpMetrics) Unsubscribed()                                 {}
+func (noOpMetrics) Published(topic string)                        {}
+func (noOpMetrics) Enqueued(ident string)                         {}
+func (noOpMetrics) Dequeued(ident string)                         {}
+func (noOpMetrics) Consumed(ident string, duration time.Duration) {}

--- a/metrics.go
+++ b/metrics.go
@@ -8,16 +8,23 @@ import "time"
 // Metrics represents methods for collecting information about the internal
 // state of the pubsub.
 type Metrics interface {
+	// Subscribed metric increments to show the number of subscriptions per
+	// hub.
+	Subscribed()
+
+	// Unsubscribed metric decrements the number of subscriptions the hub has.
+	Unsubscribed()
+
 	// Published metric is used to increment how many published messages are
 	// sent per topic.
 	Published(topic string)
 
-	// Enqueued metrics increments the number of messages a subscriber has
+	// Enqueued metric increments the number of messages a subscriber has
 	// currently. This can be used to see if a subscriber has a backlog of
 	// messages pilling up.
 	Enqueued(index int)
 
-	// Dequeued metrics decrements the message count once the subscriber has
+	// Dequeued metric decrements the message count once the subscriber has
 	// in the pending queue. This doesn't tell you if the message was consumed
 	// via the callback, or how long it took.
 	Dequeued(index int)
@@ -29,6 +36,8 @@ type Metrics interface {
 
 type noOpMetrics struct{}
 
+func (noOpMetrics) Subscribed()                                {}
+func (noOpMetrics) Unsubscribed()                              {}
 func (noOpMetrics) Published(topic string)                     {}
 func (noOpMetrics) Enqueued(index int)                         {}
 func (noOpMetrics) Dequeued(index int)                         {}

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,35 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package pubsub
+
+import "time"
+
+// Metrics represents methods for collecting information about the internal
+// state of the pubsub.
+type Metrics interface {
+	// Published metric is used to increment how many published messages are
+	// sent per topic.
+	Published(topic string)
+
+	// Enqueued metrics increments the number of messages a subscriber has
+	// currently. This can be used to see if a subscriber has a backlog of
+	// messages pilling up.
+	Enqueued(index int)
+
+	// Dequeued metrics decrements the message count once the subscriber has
+	// in the pending queue. This doesn't tell you if the message was consumed
+	// via the callback, or how long it took.
+	Dequeued(index int)
+
+	// Consumed metric identifies the number of consumed messages the subscriber
+	// has consumed since a message was enqueued.
+	Consumed(index int, duration time.Duration)
+}
+
+type noOpMetrics struct{}
+
+func (noOpMetrics) Published(topic string)                     {}
+func (noOpMetrics) Enqueued(index int)                         {}
+func (noOpMetrics) Dequeued(index int)                         {}
+func (noOpMetrics) Consumed(index int, duration time.Duration) {}

--- a/simplehub.go
+++ b/simplehub.go
@@ -127,7 +127,13 @@ func (h *SimpleHub) SubscribeMatch(matcher func(string) bool, handler func(strin
 	sub.id = h.idx
 	h.idx++
 	h.subscribers = append(h.subscribers, sub)
-	unsub := &handle{hub: h, id: sub.id}
+	unsub := &handle{
+		hub: h,
+		id:  sub.id,
+	}
+
+	h.metrics.Subscribed()
+
 	return unsub.Unsubscribe
 }
 
@@ -139,6 +145,7 @@ func (h *SimpleHub) unsubscribe(id int) {
 		if sub.id == id {
 			sub.close()
 			h.subscribers = append(h.subscribers[0:i], h.subscribers[i+1:]...)
+			h.metrics.Unsubscribed()
 			return
 		}
 	}

--- a/simplehub.go
+++ b/simplehub.go
@@ -3,7 +3,11 @@
 
 package pubsub
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/juju/clock"
+)
 
 var prePublishTestHook func()
 
@@ -12,6 +16,21 @@ type SimpleHubConfig struct {
 	// Logger allows specifying a logging implementation for debug
 	// and trace level messages emitted from the hub.
 	Logger Logger
+	// Metrics allows the passing in of a metrics collector.
+	Metrics Metrics
+	// Clock defines a clock to help improve test coverage.
+	Clock clock.Clock
+}
+
+// SimpleHub provides the base functionality of dealing with subscribers,
+// and the notification of subscribers of events.
+type SimpleHub struct {
+	mutex       sync.Mutex
+	subscribers []*subscriber
+	idx         int
+	logger      Logger
+	metrics     Metrics
+	clock       clock.Clock
 }
 
 // NewSimpleHub returns a new SimpleHub instance.
@@ -29,19 +48,20 @@ func NewSimpleHub(config *SimpleHubConfig) *SimpleHub {
 	if logger == nil {
 		logger = noOpLogger{}
 	}
+	metrics := config.Metrics
+	if metrics == nil {
+		metrics = noOpMetrics{}
+	}
+	time := config.Clock
+	if time == nil {
+		time = clock.WallClock
+	}
 
 	return &SimpleHub{
-		logger: logger,
+		logger:  logger,
+		metrics: metrics,
+		clock:   time,
 	}
-}
-
-// SimpleHub provides the base functionality of dealing with subscribers,
-// and the notification of subscribers of events.
-type SimpleHub struct {
-	mutex       sync.Mutex
-	subscribers []*subscriber
-	idx         int
-	logger      Logger
 }
 
 // Publish will notify all the subscribers that are interested by calling
@@ -73,6 +93,8 @@ func (h *SimpleHub) Publish(topic string, data interface{}) func() {
 		}
 	}
 
+	h.metrics.Published(topic)
+
 	return wait.Wait
 }
 
@@ -101,7 +123,7 @@ func (h *SimpleHub) SubscribeMatch(matcher func(string) bool, handler func(strin
 	h.mutex.Lock()
 	defer h.mutex.Unlock()
 
-	sub := newSubscriber(matcher, handler, h.logger)
+	sub := newSubscriber(matcher, handler, h.logger, h.metrics, h.clock)
 	sub.id = h.idx
 	h.idx++
 	h.subscribers = append(h.subscribers, sub)

--- a/simplehub_test.go
+++ b/simplehub_test.go
@@ -288,6 +288,9 @@ func newTestMetrics() *testMetrics {
 	}
 }
 
+func (m *testMetrics) Subscribed()   {}
+func (m *testMetrics) Unsubscribed() {}
+
 func (m *testMetrics) Published(topic string) {
 	m.mutex.Lock()
 	m.published[topic]++

--- a/structuredhub.go
+++ b/structuredhub.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"reflect"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 )
 
@@ -40,6 +41,12 @@ type StructuredHubConfig struct {
 	// Logger allows specifying a logging implementation for debug
 	// and trace level messages emitted from the hub.
 	Logger Logger
+
+	// Metrics allows the passing in of a metrics collector.
+	Metrics Metrics
+
+	// Clock defines a clock to help improve test coverage.
+	Clock clock.Clock
 
 	// Marshaller defines how the structured hub will convert from structures to
 	// a map[string]interface{} and back. If this is not specified, the
@@ -80,12 +87,22 @@ func NewStructuredHub(config *StructuredHubConfig) *StructuredHub {
 	if logger == nil {
 		logger = noOpLogger{}
 	}
+	metrics := config.Metrics
+	if metrics == nil {
+		metrics = noOpMetrics{}
+	}
+	time := config.Clock
+	if time == nil {
+		time = clock.WallClock
+	}
 	if config.Marshaller == nil {
 		config.Marshaller = JSONMarshaller
 	}
 	return &StructuredHub{
 		hub: SimpleHub{
-			logger: logger,
+			logger:  logger,
+			metrics: metrics,
+			clock:   time,
 		},
 		marshaller:  config.Marshaller,
 		annotations: config.Annotations,

--- a/subscriber.go
+++ b/subscriber.go
@@ -105,6 +105,10 @@ func (s *subscriber) loop() {
 			// information to workout how much backpressure is being exhorted
 			// on the system at large.
 			s.metrics.Consumed(s.handlerName, s.clock.Now().Sub(message.now))
+		} else {
+			// Although it shouldn't happen, we should at least log out when it
+			// does, so we can investigate when it does.
+			s.logger.Errorf("programatic error: message was nil")
 		}
 	}
 }

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -1,0 +1,39 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package pubsub_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/pubsub/v2"
+)
+
+type SubscriberSuite struct{}
+
+var _ = gc.Suite(&SubscriberSuite{})
+
+func (s SubscriberSuite) TestGetFunctionName(c *gc.C) {
+	tests := []struct {
+		fn   func()
+		name string
+	}{{
+		fn:   func() {},
+		name: "TestGetFunctionName.func1",
+	}, {
+		fn:   s.method,
+		name: "SubscriberSuite.method",
+	}, {
+		fn:   method,
+		name: "com/juju/pubsub/v2_test.method",
+	}}
+
+	for _, test := range tests {
+		name := pubsub.GetFunctionName(test.fn, 0)
+		c.Assert(name, gc.Equals, test.name)
+	}
+}
+
+func (s SubscriberSuite) method() {}
+
+func method() {}

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -28,7 +28,8 @@ func (s SubscriberSuite) TestGetFunctionName(c *gc.C) {
 		name: "com/juju/pubsub/v2_test.method",
 	}}
 
-	for _, test := range tests {
+	for k, test := range tests {
+		c.Logf("test %d", k)
 		name := pubsub.GetFunctionName(test.fn, 0)
 		c.Assert(name, gc.Equals, test.name)
 	}


### PR DESCRIPTION
The following exposes the underlying status of a subscriber queue. The
queue per subscriber can be susceptible to back pressure from the slow
callbacks. We currently don't have any visibility of how this manifests
as we don't have any metrics to observe. The following commit exposes
this in convenient methods that each hub can implement.

Implementations of the metrics interface should be careful around data
races, as the metrics type walks across many goroutines.

### Benchmarks

#### Pre changes

```
$ go test -v ./... -check.b
=== RUN   TestPackage
PASS: benchmarks_test.go:19: BenchmarkSuite.BenchmarkStructuredNoConversions      500000              4227 ns/op
PASS: benchmarks_test.go:43: BenchmarkSuite.BenchmarkStructuredSerialize          100000             17552 ns/op
OK: 2 passed
--- PASS: TestPackage (4.13s)
PASS
ok      github.com/juju/pubsub/v2       4.142s

```


#### Post changes

```
$ go test -v ./... -check.b
=== RUN   TestPackage
PASS: benchmarks_test.go:19: BenchmarkSuite.BenchmarkStructuredNoConversions      500000              4798 ns/op
PASS: benchmarks_test.go:43: BenchmarkSuite.BenchmarkStructuredSerialize          100000             18281 ns/op
OK: 2 passed
--- PASS: TestPackage (4.51s)
PASS
ok      github.com/juju/pubsub/v2       4.524s
```

#### Post changes with function naming

```
go test -v ./... -check.b
=== RUN   TestPackage
PASS: benchmarks_test.go:19: BenchmarkSuite.BenchmarkStructuredNoConversions      500000              4641 ns/op
PASS: benchmarks_test.go:43: BenchmarkSuite.BenchmarkStructuredSerialize          100000             18359 ns/op
OK: 2 passed
--- PASS: TestPackage (4.44s)
PASS
ok      github.com/juju/pubsub/v2       4.453s
````