### PR TITLE
[JUJU-332] Fix programmatic errors in production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,6 @@ check-go:
 		echo go fmt is sad: $(GOFMT); \
 		exit 1; \
 	fi )
-	@(go tool vet -all -composites=false -copylocks=false .)
+	@(go vet -all .)
 
 .PHONY: default check docs check-licence check-go

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.14
 
 require (
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
-	github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c
 	github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18
 	github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9 // indirect
 	github.com/juju/retry v0.0.0-20151029024821-62c620325291 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
 github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c h1:3UvYABOQRhJAApj9MdCN+Ydv841ETSoy6xLzdmmr/9A=
 github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
-github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c/go.mod h1:Ep+c0vnxsgmmTtsMibPgEEleZyi0b4uVvyzJ+8ka9EI=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/retry v0.0.0-20151029024821-62c620325291/go.mod h1:OohPQGsr4pnxwD5YljhQ+TZnuVRYpa5irjugL1Yuif4=

--- a/simplehub.go
+++ b/simplehub.go
@@ -85,10 +85,10 @@ func (h *SimpleHub) Publish(topic string, data interface{}) func() {
 	for _, s := range h.subscribers {
 		if s.topicMatcher(topic) {
 			wait.Add(1)
-			s.notify(&handlerCallback{
-				topic: topic,
-				data:  data,
-				wg:    &wait,
+			s.notify(handlerCallback{
+				topic:  topic,
+				data:   data,
+				doneFn: wait.Done,
 			})
 		}
 	}
@@ -158,11 +158,11 @@ func Wait(done func()) <-chan struct{} {
 }
 
 type handlerCallback struct {
-	topic string
-	data  interface{}
-	wg    *sync.WaitGroup
+	topic  string
+	data   interface{}
+	doneFn func()
 }
 
 func (h *handlerCallback) done() {
-	h.wg.Done()
+	h.doneFn()
 }

--- a/subscriber.go
+++ b/subscriber.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/juju/clock"
-	"github.com/juju/collections/deque"
 )
 
 type subscriber struct {
@@ -26,21 +25,15 @@ type subscriber struct {
 	handler      func(topic string, data interface{})
 	handlerName  string
 
-	mutex   sync.Mutex
-	pending *deque.Deque
-	closed  chan struct{}
-	data    chan struct{}
-	done    chan struct{}
+	msgQueue *queue
+	data     chan struct{}
+	done     chan struct{}
 }
 
 func newSubscriber(id int,
 	matcher func(topic string) bool,
 	handler func(string, interface{}),
 	logger Logger, metrics Metrics, clock clock.Clock) *subscriber {
-	// A closed channel is used to provide an immediate route through a select
-	// call in the loop function.
-	closed := make(chan struct{})
-	close(closed)
 	sub := &subscriber{
 		id:           id,
 		logger:       logger,
@@ -49,10 +42,9 @@ func newSubscriber(id int,
 		topicMatcher: matcher,
 		handler:      handler,
 		handlerName:  getFunctionName(handler, id),
-		pending:      deque.New(),
+		msgQueue:     makeQueue(),
 		data:         make(chan struct{}, 1),
 		done:         make(chan struct{}),
-		closed:       closed,
 	}
 	go sub.loop()
 	sub.logger.Tracef("created subscriber %p for %v", sub, matcher)
@@ -60,12 +52,10 @@ func newSubscriber(id int,
 }
 
 func (s *subscriber) close() {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
 	// need to iterate through all the pending calls and make sure the wait group
 	// is decremented. this isn't exposed yet, but needs to be.
-	for call, ok := s.pending.PopFront(); ok; call, ok = s.pending.PopFront() {
-		call.(*message).callback.done()
+	for message, ok := s.msgQueue.Dequeue(); ok; message, ok = s.msgQueue.Dequeue() {
+		message.callback.done()
 
 		// Notify the metrics that although we've closed the subscriber, all the
 		// messages that subscriber had, have been drained.
@@ -75,26 +65,16 @@ func (s *subscriber) close() {
 }
 
 func (s *subscriber) loop() {
-	var next <-chan struct{}
 	for {
 		select {
 		case <-s.done:
 			return
 		case <-s.data:
-			// Has new data been pushed on?
-		case <-next:
-			// If there was already data, next is a closed channel.
-			// otherwise it is nil so won't pass through.
 		}
-		message, empty := s.popOne()
-		if empty {
-			next = nil
-		} else {
-			next = s.closed
-		}
-		// message *should* never be nil as we should only be calling
-		// popOne in the situations where there is actually something to pop.
-		if message != nil {
+
+		for message, ok := s.msgQueue.Dequeue(); ok; message, ok = s.msgQueue.Dequeue() {
+			s.metrics.Dequeued(s.handlerName)
+
 			call := message.callback
 			s.logger.Tracef("exec callback %p (%d) func %p", s, s.id, s.handler)
 			s.handler(call.topic, call.data)
@@ -105,50 +85,30 @@ func (s *subscriber) loop() {
 			// information to workout how much backpressure is being exhorted
 			// on the system at large.
 			s.metrics.Consumed(s.handlerName, s.clock.Now().Sub(message.now))
-		} else {
-			// Although it shouldn't happen, we should at least log out when it
-			// does, so we can investigate when it does.
-			s.logger.Errorf("programatic error: message was nil")
 		}
 	}
 }
 
-func (s *subscriber) popOne() (*message, bool) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	val, ok := s.pending.PopFront()
-	if !ok {
-		// nothing to do
-		return nil, true
-	}
-
-	// Notify the metrics that we've dequeued an message from the list.
-	s.metrics.Dequeued(s.handlerName)
-
-	empty := s.pending.Len() == 0
-	return val.(*message), empty
-}
-
-func (s *subscriber) notify(call *handlerCallback) {
+func (s *subscriber) notify(call handlerCallback) {
 	s.logger.Tracef("notify %d", s.id)
 
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	s.pending.PushBack(&message{
+	s.msgQueue.Enqueue(message{
 		now:      s.clock.Now(),
 		callback: call,
 	})
-	if s.pending.Len() == 1 {
-		s.data <- struct{}{}
+
+	select {
+	case s.data <- struct{}{}:
+	default:
+		// Notification pending to be processed
 	}
+
 	// Notify the metrics that we're enqueuing a new item onto the subscriber.
 	s.metrics.Enqueued(s.handlerName)
 }
 
 type message struct {
-	callback *handlerCallback
+	callback handlerCallback
 	now      time.Time
 }
 
@@ -176,4 +136,67 @@ func getFunctionName(i interface{}, fallback int) string {
 		name = name[:idx]
 	}
 	return name
+}
+
+type queueElement struct {
+	msg  message
+	next *queueElement
+}
+
+type queue struct {
+	elemPool sync.Pool
+
+	mu   sync.Mutex
+	head *queueElement
+	tail *queueElement
+}
+
+func makeQueue() *queue {
+	return &queue{
+		elemPool: sync.Pool{
+			New: func() interface{} {
+				return new(queueElement)
+			},
+		},
+	}
+}
+
+// Enqueue a message onto the queue.
+func (q *queue) Enqueue(msg message) {
+	elem := q.elemPool.Get().(*queueElement)
+	elem.msg = msg
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.head == nil {
+		q.head = elem
+		q.tail = elem
+		return
+	}
+
+	q.tail.next = elem
+	q.tail = elem
+}
+
+// Dequeue a message from the queue. Returns a message or true if it's empty.
+func (q *queue) Dequeue() (message, bool) {
+	q.mu.Lock()
+
+	if q.head == nil {
+		q.mu.Unlock()
+		return message{}, false // empty
+	}
+
+	elem := q.head
+	q.head = elem.next
+	if q.head == nil {
+		q.tail = nil
+	}
+	msg := elem.msg
+	q.mu.Unlock()
+
+	elem.next = nil
+	q.elemPool.Put(elem)
+	return msg, true
 }


### PR DESCRIPTION
Every so often we can end up with a nil message. Which either means we
dropped a message or we're attempting to process a message that isn't
there. This can lead to issues in people attempting to use the library.

To simplify the subscriber code for pubsub, I and @achilleasa
implemented a single linked list that we can enqueue and dequeue.

Removing the complexity of knowing when to request the next message. It
removes the ambiguity of knowing if you have a next message or not. The
trick of knowing when next is blocking or not is also gone, as we can
use the existing data channel. If that's already full (it's a buffered
channel of 1), then just offer a default case in the select to allow the
bypassing of the blocking operation.

Message pointers in the implementation is gone, you either have a
message or you don't. We no longer need to check for empty. And in
doing so, the implementation iterates all the pending handlers at onces,
without checking for data or next each iteration.

The benchmark performance is on par against the existing implementation.
Splitting hairs between implementations.

New:

     PASS: benchmarks_test.go:19: BenchmarkSuite.BenchmarkStructuredNoConversions      500000   4604 ns/op
     PASS: benchmarks_test.go:43: BenchmarkSuite.BenchmarkStructuredSerialize          100000   18301 ns/op

Old:

     PASS: benchmarks_test.go:19: BenchmarkSuite.BenchmarkStructuredNoConversions      500000   4781 ns/op
     PASS: benchmarks_test.go:43: BenchmarkSuite.BenchmarkStructuredSerialize          100000   18633 ns/op